### PR TITLE
ci: Fix RSS dates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # RSS plugin needs all history
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x


### PR DESCRIPTION
现在RSS显示的日期都是编译日期，正常应该按提交记录来。需要告诉插件全部历史才行。

（我不太清楚 vercel 怎么办，不过不太重要，大不了不改了。）